### PR TITLE
Fixed Invalid ENV format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM       debian
 MAINTAINER Maxime Vidori <maxime.vidori@gmail.com>
 
 
-ENV HTML5_BOILERPLATE_URL="http://www.initializr.com/builder?"\
+ENV HTML5_BOILERPLATE_URL "http://www.initializr.com/builder?"\
 "h5bp-content&html5shiv&h5bp-favicon&h5bp-404&h5bp-css&h5bp-csshelpers&"\
 "h5bp-mediaqueryprint&h5bp-mediaqueries&simplehtmltag&izr-emptyscript"
 


### PR DESCRIPTION
I had to change it to compile in ubuntu 14.04, with the old attribute it works in archlinux but not in Ubuntu 14.04.
